### PR TITLE
Fixed the Command of the Compilation Step

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ purposes.
 - Basic understanding of shellcode operations.
 - Familiarity with C#, Rust, PowerShell, ASPX, or VBA.
 
-### ⬇️ Installation
+### ⬇️ Compilation
 
 To clone and run this application, you'll need Git installed on your computer. From your command line:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ git clone https://github.com/zerx0r/dvenom
 # Go into the repository
 $ cd dvenom
 # Build the application
-$ go build /cmd/dvenom/
+$ go build -o dvenom cmd/dvenom/main.go
 ```
 
 ## 🎮 Usage


### PR DESCRIPTION
Made a slight modification to the compilation command as it wasn't working properly when executed as listed in the README file. The issue is shown below:

```
$ git clone https://github.com/omr00t/dvenom                                                                                         
...                                                                                            
$ cd dvenom/                                                                                                                         
$ go build /cmd/dvenom/                                                                                                              
stat /cmd/dvenom: directory not found                                                                                                
```

Also labeled the step as "Compilation" instead of "Installation" as that step should merely compile the binary.